### PR TITLE
Override AbstractProvider->httpBuildQuery() in Square provider

### DIFF
--- a/src/Provider/Square.php
+++ b/src/Provider/Square.php
@@ -145,4 +145,14 @@ class Square extends AbstractProvider
 
         return parent::prepareAccessTokenResult($result);
     }
+
+    protected function httpBuildQuery($params, $numeric_prefix = 0, $arg_separator = '&', $enc_type = null)
+    {
+        // Remove approval_prompt parameter and sort remaining parameters to
+        // avoid a superfluous redirect by Square
+        unset($params['approval_prompt']);
+        ksort($params);
+
+        return parent::httpBuildQuery($params, $numeric_prefix, $arg_separator, $enc_type);
+    }
 }


### PR DESCRIPTION
Square appears to perform a superfluous redirect during the OAuth
workflow that does two things: 1) sorts query string parameters; 2)
removes an approval_prompt parameter automatically added by
`AbstractProvider->getAuthorizationUrl()`.

At best, this adds a needless request to the OAuth workflow, making it
take longer. It appears that it may also be causing the workflow to fail
in `Square->prepareAccessTokenResult()` within a local development environment.