### PR TITLE
Add support for changing the Square URL.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - hhvm
 
 before_script:
-  - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source --dev
   - composer require satooshi/php-coveralls --dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ php:
   - 5.6
   - hhvm
 
+jobs:
+  allow_failures:
+    - php: hhvm
+
 before_script:
   - travis_retry composer install --no-interaction --prefer-source --dev
   - composer require satooshi/php-coveralls --dev

--- a/src/Provider/Square.php
+++ b/src/Provider/Square.php
@@ -12,27 +12,27 @@ use League\OAuth2\Client\Grant\RefreshToken;
 
 class Square extends AbstractProvider
 {
-    /**
-     * Enable debugging by connecting to the Square staging server.
-     *
-     * @var boolean
-     */
-    public $debug = false;
-
     public $uidKey = 'merchant_id';
 
     public $scopeSeparator = ' ';
 
     /**
-     * Get a Square connect URL, depending on path.
+     * $baseUrl is used to target different square environments. It defaults to connect.squareup.com
+     *
+     * @var string
+     */
+    public $baseUrl = 'connect.squareup.com';
+
+    /**
+     * Get a Square connect URL, depending on path. This will use the $baseUrl to build the connect url. If you want
+     * to target a different square API (such as a sandbox); you will need to change the baseUrl.
      *
      * @param  string $path
      * @return string
      */
     public function getConnectUrl($path)
     {
-        $staging = $this->debug ? 'staging' : '';
-        return "https://connect.squareup{$staging}.com/{$path}";
+        return "https://{$this->baseUrl}/{$path}";
     }
 
     public function urlAuthorize()


### PR DESCRIPTION
This allows the Square URL to be changed so I can target connect.squareupsandbox.com or any other square environment.